### PR TITLE
bug fix

### DIFF
--- a/gatsby/src/templates/Architecture.js
+++ b/gatsby/src/templates/Architecture.js
@@ -159,9 +159,9 @@ const SingleArchitectureProject = ({ data: {architecture, header}, pageContext})
                         }
                     </div>
                 </div>
-                <button className="closeButton">
+                <span className="closeButton">
                     <img className="close" src='/Close.svg' alt='Close button' />
-                </button>
+                </span>
                 <div className="cont">
                     <div className="top">
                         <h2>{architecture.title}</h2>


### PR DESCRIPTION
Replaced < button > with < span >.

It's illegal to put < button > inside of a < button >. This was working fine in dev mode but after building it applies strict rules and takes the nested components out.

Reason: https://stackoverflow.com/questions/64560112/layout-mismatch-between-development-build-in-gatsby